### PR TITLE
Head quotation 의 번역 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> "C++은 작고 간단하면서도 안전한 언어이며, 많은 사람들이 사용할 수 있도록 고군분투하고 있다. (Within C++ is a smaller, simpler, safer language struggling to get out.)"
+> "C++ 안에는 밖으로 빠져나오려고 애쓰고 있는 더 작고 단순하며 안전한 언어가 있다. (Within C++ is a smaller, simpler, safer language struggling to get out.)"
 > -- <cite>비야네 스트롭스트룹(Bjarne Stroustrup)</cite>
 
 # C++ 핵심 가이드라인 한글화 프로젝트


### PR DESCRIPTION
맨 앞에 나오는 Bjarne Stroustrup의 인용구가 전혀 다른 뜻으로 번역된 것 같습니다. 
Bjarne가 동영상 강좌 등에서 이 문장("Within C++ is a smaller, simpler, safer language struggling to get out.")을 언급하는 걸 여러번 본적이 있습니다. 주로 C++ 계속 지키고 있는 C와 호환성을 이슈등을 다룰 때 많이 언급되는데요, 문맥상의 내용은 C++ 자체는 상당히 복잡한 언어이고 안전하지 않은 언어라는 겁니다. 그리고 그 안에 subset으로 존재하는 '언어'가 따로 있다는 거죠. 여기서 subset 이란 주로 C와의 호환성 때문에 유지하고 있는 부분을 제외한 것이겠죠.
생각해보면 CppCoreGuidelines 문서의 맨 앞에서 저 문장을 인용한 이유는, 이 문서가 지향하는 바가 그 '더 작고 단순하며 안전한' 언어를 사용하게 하는 가이드라인을 제시하는 것이기도 합니다. 이런 문서를 만들고 번역하는 모든 행위가 위 문장에서 언급된 "struggling"의 일환이라고 보시면 되겠습니다.
