### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,10 @@ markdown_extensions:
 
 theme:
   name: "material"
+  language: "kr"
   extra:
     search:
-      language: "en, kr"
+      language: "en"
   font:
     text: "Nanum Gothic"
     code: "Nanum Gothic Coding"


### PR DESCRIPTION
1. [사이트 언어 설정](https://github.com/squidfunk/mkdocs-material/blob/6.2.8/docs/setup/changing-the-language.md)을 한국어로 설정했습니다.
2. mkdocs-material 테마의 [사이트 검색 언어 설정](https://github.com/squidfunk/mkdocs-material/blob/6.2.8/docs/setup/setting-up-site-search.md)에는 한국어를 지원하지 않기 때문에 사이트 검색 언어 설정에서 한국어를 제외 했습니다. 비록 사이트 검색 언어 설정이 영어로만 되어 있지만 이렇게 변경하는 경우 한국어 단어 검색이 가능해집니다.
    + Before: ![search_before](https://user-images.githubusercontent.com/86359663/127752310-fe3fa26d-adeb-465b-a3e0-38dae3827525.png)
    + After: ![search_after](https://user-images.githubusercontent.com/86359663/127752320-eb14fcf2-48c9-4e4c-9bf0-629c38bc722e.png)
