### PR TITLE
Enable dark theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,8 +25,16 @@ theme:
     text: "Nanum Gothic"
     code: "Nanum Gothic Coding"
   palette:
-    primary: "Indigo"
-    accent: "blue"
+    - scheme: default
+      toggle:
+        icon: material/weather-sunny 
+        name: Switch to light mode
+      primary: "Indigo"
+      accent: "blue"
+    - scheme: slate
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
   feature:
     tabs: true
   logo: "images/logo.svg"


### PR DESCRIPTION
1. setting theme color default or black
2. dark theme use default primary, accent tag

hello, I see web site in monitor, I think Dark mode may be required.

In terms of UI, only the theme was changed and the primary and accent settings were kept as default, but I will modify them if changes are necessary.
